### PR TITLE
feat(artist-details): render artist data and albums in modal

### DIFF
--- a/src/css/partials/artist-detail-modal.css
+++ b/src/css/partials/artist-detail-modal.css
@@ -37,14 +37,19 @@
   text-align: center;
 }
 
-.artist-modal-album-img {
+.artist-modal-img-wrapper {
   border-radius: 16px;
   width: 100%;
-  height: 167px;
   margin-left: auto;
   margin-right: auto;
-  margin-top: 16px;
-  margin-bottom: 32px;
+  /* margin-top: 16px;
+  margin-bottom: 32px; */
+  overflow: hidden;
+  object-fit: cover;
+}
+
+.artist-modal-album-img {
+  object-fit: cover;
 }
 
 .artist-modal-album-list {
@@ -208,9 +213,9 @@
   }
 
   .artist-modal-album-img {
-    height: 402px;
-    width: 654px;
-    margin-top: 48px;
+    height: auto;
+    width: 100%;
+    /* margin-top: 48px; */
   }
 
   .artist-modal-album-list-wrapper {
@@ -233,6 +238,7 @@
   }
 
   .biography-paragraph {
+    overflow-y: auto;
     width: 654px;
   }
 
@@ -279,23 +285,29 @@
 
   .artist-modal-biography-field {
     display: flex;
-    width: 1184px;
     align-items: flex-start;
     gap: 32px;
     margin-bottom: 48px;
     margin-top: 48px;
   }
-
+  .artist-modal-img-wrapper,
+  .artist-modal-album-list-wrapper {
+    width: calc((100% - 32px) / 2);
+  }
+  /* .artist-modal-img-wrapper {
+    width: 50%;
+  }
   .artist-modal-album-img {
+  
     width: 576px;
-    height: 354px;
+    height: auto;
     margin: 0;
   }
 
   .artist-modal-album-list-wrapper {
     margin-bottom: 0;
     width: 576px;
-  }
+  } */
 
   .biography-paragraph {
     max-width: 576px;

--- a/src/js/api/soundWaveAPI.js
+++ b/src/js/api/soundWaveAPI.js
@@ -6,6 +6,7 @@ const soundWaveAPI = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
 const PER_PAGE = 8;
 const ENDPOINTS = {
   ARTISTS: '/artists',

--- a/src/js/presenters/artist-details-presenter.js
+++ b/src/js/presenters/artist-details-presenter.js
@@ -1,10 +1,12 @@
 import { getArtistDetails } from '../api/soundWaveAPI';
 import { openModal } from '../utils/modal-controller';
+import { renderArtistDetails } from '../views/artist-details-view';
 
 export async function handleArtistDetails(id) {
   try {
     const data = await getArtistDetails(id);
     console.log(data);
+    renderArtistDetails(data);
     openModal('#artist-modal');
   } catch (error) {
     console.error('An error occurred while loading the data:', error);

--- a/src/js/views/artist-details-view.js
+++ b/src/js/views/artist-details-view.js
@@ -1,0 +1,90 @@
+export function renderArtistDetails(data) {
+  document.querySelector('.artist-modal-name').textContent = data.strArtist;
+
+  document.querySelector('.artist-modal-album-img').src = data.strArtistThumb;
+  document.querySelector('.artist-modal-album-img').alt = data.strArtist;
+
+  document.querySelector('.biography-paragraph').textContent =
+    data.strBiographyEN;
+
+  const infoItems = document.querySelectorAll('.artist-modal-album-list-item');
+  infoItems[0].querySelector('.modal-album-list-item-value').textContent =
+    formatYears(data.intFormedYear, data.intDiedYear);
+  infoItems[1].querySelector('.modal-album-list-item-value').textContent =
+    data.strGender;
+  infoItems[2].querySelector('.modal-album-list-item-value').textContent =
+    data.intMembers;
+  infoItems[3].querySelector('.modal-album-list-item-value').textContent =
+    data.strCountry;
+
+  const genresList = document.querySelector('.artist-modal-genres-list');
+  genresList.innerHTML = '';
+  if (data.strLabel) {
+    genresList.innerHTML = `<li class="artist-modal-genres-list-item">${data.strLabel}</li>`;
+  }
+
+  renderAlbums(data.tracksList);
+}
+
+function formatYears(start, end) {
+  return end ? `${start}–${end}` : `${start}–present`;
+}
+
+function renderAlbums(tracks) {
+  const albumsWrapper = document.querySelector(
+    '.artist-modal-fetched-albums-wrapper'
+  );
+  albumsWrapper.innerHTML = ''; // Очистити
+
+  const grouped = groupTracksByAlbum(tracks);
+
+  Object.entries(grouped).forEach(([album, tracks]) => {
+    const albumBlock = document.createElement('div');
+    albumBlock.classList.add('artist-modal-album-container');
+
+    albumBlock.innerHTML = `
+        <h4 class="artist-modal-album-name">${album}</h4>
+        <ul class="artist-modal-album-track-header-list">
+          <li class="artist-modal-album-track-header-list-item">Track</li>
+          <li class="artist-modal-album-track-header-list-item">Time</li>
+          <li class="artist-modal-album-track-header-list-item">Link</li>
+        </ul>
+        <ul class="artist-modal-track-list">
+          ${tracks
+            .map(
+              track => `
+            <li class="artist-modal-track-list-item">
+              <p class="artist-modal-track-list-item-song">${track.strTrack}</p>
+              <p class="artist-modal-track-list-item-time">${formatTime(
+                track.intDuration
+              )}</p>
+              <a class="artist-modal-track-list-item-link" href="${
+                track.movie || '#'
+              }" target="_blank">
+                <svg class="artist-modal-track-list-item-svg" width="24" height="24" aria-hidden="true">
+                  <use href="../assets/svg/sprite.svg#icon-youtube"></use>
+                </svg>
+              </a>
+            </li>`
+            )
+            .join('')}
+        </ul>
+      `;
+    albumsWrapper.append(albumBlock);
+  });
+}
+
+function groupTracksByAlbum(tracks) {
+  return tracks.reduce((acc, track) => {
+    acc[track.strAlbum] = acc[track.strAlbum] || [];
+    acc[track.strAlbum].push(track);
+    return acc;
+  }, {});
+}
+
+function formatTime(ms) {
+  const totalSec = Math.floor(Number(ms) / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = String(totalSec % 60).padStart(2, '0');
+  return `${min}:${sec}`;
+}

--- a/src/partials/artist-detail-modal.html
+++ b/src/partials/artist-detail-modal.html
@@ -13,11 +13,13 @@
 
     <h2 class="artist-modal-name">Unlike Pluto</h2>
     <div class="artist-modal-biography-field">
-      <img
-        class="artist-modal-album-img"
-        src="../assets/images/artist-detail-modal/desk-artist-modal-img.webp"
-        alt="description"
-      />
+      <div class="artist-modal-img-wrapper">
+        <img
+          class="artist-modal-album-img"
+          src="../assets/images/artist-detail-modal/desk-artist-modal-img.webp"
+          alt="description"
+        />
+      </div>
 
       <div class="artist-modal-album-list-wrapper">
         <ul class="artist-modal-album-list">


### PR DESCRIPTION
- Added renderArtistDetails function in artist-details-view.js.
- Rendered artist name, photo, biography, gender, country, members, and label.
- Grouped and rendered track list by album inside the modal.
- Dynamically generated track duration and YouTube links.
- Connected render logic to handleArtistDetails() in presenter.